### PR TITLE
Add dependency: pyside6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     - cellpose = cellpose.__main__:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -42,6 +42,7 @@ requirements:
     - scikit-image    # Imported but not declared as a dependency
     - tqdm
     # GUI Dependencies
+    - pyside6
     - pyqtgraph >=0.11.0rc0
     - qtpy
     - superqt


### PR DESCRIPTION
I noticed that the gui doesn't run out-of-the-box without installing either PyQt or PySide, so let's include one of them in the dependencies.

The cellpose pip package [lists PyQt6][1], but IIUC that has an incompatible license, so I'm proposing to add PySide here.

[1]: https://github.com/MouseLand/cellpose/blob/15eb3c6831ac19e0948dbc38c11016d11d1aacf3/setup.py#L23

With this change, installing and running cellpose (with all dependencies) looks like this:

```bash
conda create -n my-cellpose-env cellpose
conda activate my-cellpose-env
python -m cellpose
```

Or, using `pixi` (preferred, IMO), it looks like this:

```bash
mkdir my-cellpose-workspace
cd my-cellpose-workspace
pixi init
pixi add cellpose
pixi run python -m cellpose
```

(Side note: In either case, they'll automatically get the appropriate version of `pytorch` (CPU vs. GPU) and related libraries based on the capabilities of the system they are installing on.)

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
